### PR TITLE
update

### DIFF
--- a/home/desktop/catppuccin.nix
+++ b/home/desktop/catppuccin.nix
@@ -7,5 +7,12 @@
     fcitx5.apply = false;
     hyprlock.useDefaultConfig = false;
     wezterm.apply = true;
+    tmux.extraConfig = ''
+      set -g @catppuccin_window_status_style "rounded"
+      set -g status-left ""
+      set -g status-right "#{E:@catppuccin_status_application}"
+      set -ag status-right "#{E:@catppuccin_status_session}"
+      set -ag status-right "#{E:@catppuccin_status_host}"
+    '';
   };
 }

--- a/home/desktop/clipboard/default.nix
+++ b/home/desktop/clipboard/default.nix
@@ -1,8 +1,7 @@
-{ ... }:
-
 {
   imports = [
     ./copyq.nix
     ./cliphist
   ];
+  services.wl-clip-persist.enable = true;
 }

--- a/home/desktop/wayland/niri/config.kdl
+++ b/home/desktop/wayland/niri/config.kdl
@@ -303,7 +303,7 @@ binds {
     Mod+Alt+Space hotkey-overlay-title="Calcuate: rofi" {
         spawn-sh "pkill rofi || rofi -show calc -modi calc -no-show-match -no-sort -no-history -calc-command \"echo -n '{result}' | wl-copy\""
     }
-    Mod+Shift+Escape hotkey-overlay-title="Lock the Screen: hyprlock" {
+    Mod+Shift+Escape hotkey-overlay-title="Lock session" allow-when-locked=true {
         spawn "loginctl" "lock-session"
     }
     Mod+Ctrl+I allow-when-locked=true hotkey-overlay-title="Toggle inhibit lid sleep" {

--- a/home/programs/browsers/firefox/default.nix
+++ b/home/programs/browsers/firefox/default.nix
@@ -57,6 +57,7 @@ in
               darkreader
               grammarly
               keepassxc-browser
+              libredirect
               refined-github
               sponsorblock
               translate-web-pages

--- a/home/programs/browsers/firefox/default.nix
+++ b/home/programs/browsers/firefox/default.nix
@@ -19,7 +19,10 @@ in
     # https://mozilla.github.io/policy-templates
     policies = {
       Cookies = {
-        Allow = [ "https://devdocs.io" ];
+        Allow = [
+          "https://devdocs.io"
+          "https://s.dunkirk.sh"
+        ];
       };
     };
     nativeMessagingHosts = with pkgs; [ keepassxc-snapshot ];
@@ -69,14 +72,17 @@ in
         ];
       search = {
         force = true;
-        default = "Brave";
-        privateDefault = "Brave";
+        default = "unduckified";
+        privateDefault = "unduckified";
         engines = {
           SearXNG = {
             urls = [ { template = "http://localhost:8880/search?q={searchTerms}"; } ];
           };
           Brave = {
             urls = [ { template = "https://search.brave.com/search?q={searchTerms}"; } ];
+          };
+          unduckified = {
+            urls = [ { template = "https://s.dunkirk.sh?q={searchTerms}"; } ];
           };
         };
       };

--- a/home/programs/default.nix
+++ b/home/programs/default.nix
@@ -15,6 +15,7 @@
     ./productivity
     ./proxy
     ./qalculate
+    ./rss.nix
     ./social
     ./todo.nix
     ./torrent.nix

--- a/home/shell/fish/default.nix
+++ b/home/shell/fish/default.nix
@@ -23,5 +23,6 @@ in
         cat = "bat -p";
       };
     };
+    programs.man.generateCaches = false;
   };
 }

--- a/home/shell/tmux.nix
+++ b/home/shell/tmux.nix
@@ -26,6 +26,9 @@
         set -g focus-events on
         set -g default-terminal "tmux-256color"
 
+        set -g status-left-length 100
+        set -g status-right-length 100
+
         bind-key -n M-w choose-tree -w
         bind-key -n M-n new-window
         bind-key -n M-q kill-pane

--- a/home/shell/tmux.nix
+++ b/home/shell/tmux.nix
@@ -24,7 +24,7 @@
         set -g pane-base-index 1
         set -g renumber-windows on
         set -g focus-events on
-        set -g default-terminal "screen-256color"
+        set -g default-terminal "tmux-256color"
 
         bind-key -n M-w choose-tree -w
         bind-key -n M-n new-window

--- a/home/shell/tmux.nix
+++ b/home/shell/tmux.nix
@@ -22,9 +22,9 @@
       extraConfig = ''
         set -g base-index 1
         set -g pane-base-index 1
-        set-option -g renumber-windows on
-        set-option -g focus-events on
-        set-option -g default-terminal "screen-256color"
+        set -g renumber-windows on
+        set -g focus-events on
+        set -g default-terminal "screen-256color"
 
         bind-key -n M-w choose-tree -w
         bind-key -n M-n new-window

--- a/hosts/X1C12/hardware-configuration.nix
+++ b/hosts/X1C12/hardware-configuration.nix
@@ -11,6 +11,7 @@
 
 {
   imports = [
+    (modulesPath + "/hardware/cpu/intel-npu.nix")
     (modulesPath + "/installer/scan/not-detected.nix")
   ];
 
@@ -62,5 +63,6 @@
   swapDevices = [ ];
 
   nixpkgs.hostPlatform = lib.mkDefault "x86_64-linux";
+  hardware.cpu.intel.npu.enable = true;
   hardware.cpu.intel.updateMicrocode = lib.mkDefault config.hardware.enableRedistributableFirmware;
 }

--- a/lib/patch/default.nix
+++ b/lib/patch/default.nix
@@ -30,7 +30,7 @@ let
       pkgs.applyPatches {
         name = "home-manager-patched";
         src = inputs.home-manager;
-        patches = [ ];
+        patches = home-manager-patches;
       }
     else
       inputs.home-manager;

--- a/secrets/root/desktop/secrets.yaml
+++ b/secrets/root/desktop/secrets.yaml
@@ -8,6 +8,9 @@ buildbot:
 grafana: ENC[AES256_GCM,data:y/P4/oVdq5kLYzQygB1Fhjd+EySL31aG8BkFc1BMc9s=,iv:3BYsDKdoGxNrfMtE0yWkAH7yWrQ7ccl8HjJHWO2A+Ag=,tag:8VJprdOzLleCOWTQ3muu9g==,type:str]
 mihomo:
     controller-secret: ENC[AES256_GCM,data:y/uteF4onuO+evQG6HnufFAuDQijkYPtNIaZ+5LwSHk=,iv:Vyr3wFtIfF0yQM5IFI1C9z3/2ymTjFtN8GweHRN7I38=,tag:74y+nxHHtV6GoIYxc7P1bw==,type:str]
+glance:
+    secret-key: ENC[AES256_GCM,data:k/hAt5J7zeyI5jFPJow3yWnvyZmjnh6L0Xs8lxTnNh7GyWMalW/m8O7A7ETIBo4G47UYXlxZdSd0eG7XUqZs7Nv2GLvKlonm+r6ajNF9lCZ/gDuNaJgunw==,iv:LpBknkkAuBTZRjayv+cM+flaMbHTkoBSmk2GRXKaHkc=,tag:MqjXGcJurrT0/uuW6wgu0A==,type:str]
+    admin-password: ENC[AES256_GCM,data:caBsNv/3kAzJ9XDKm94Oo7skeTJ5b5PvnhNuS1xYlHjW6CSlKdz/gbFzjBW8bZHa7lv1icwwr28s3iFSqmZ8vDiQ9PaXKhRB,iv:uvdLPn+ZAEPIK9JK0q2dvSJchwKrta8XVK95/xFAJMw=,tag:XU+7Yi2THC9ZIY9XQXMPSw==,type:str]
 sops:
     age:
         - recipient: age1hf2zuvuwccu5r5u8rj5yuqapxkdjr8pnsqg6ehsgr5l7hr6meqrquqq0nx
@@ -28,7 +31,7 @@ sops:
             WEIzYUtCQUdIMXZNM2pjZm1aSEpIWEkKmS9N0L8uWbabnSTEK/bDfqZbc4d2TmBU
             goklQZDQnjAnaNvjAPTSqdG9S+HrvRL4BQtKo+TXcKKd7/RItz5gBg==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-03-15T00:04:03Z"
-    mac: ENC[AES256_GCM,data:8hVolsEM9/sskdHJkXjz2oxOWqrx6C58rBhbtIINIanAe9nX+3+NAHc22NjmuWUFH7HOLph/D7P1pPjIWPGQVgxpuyNQbk8374cy+1J9npi1LoJgvrF9UAzQW8QIiegx9BW8O5N4rEfiLQg2aB0KRkw93J5VK6CIZgDsfUinsBo=,iv:sBX4uik5scvuR7887vIafEXcu8Ne1wHwpIIaj8UZ32M=,tag:cTORbQ8JAm+MzIveEw+C9g==,type:str]
+    lastmodified: "2026-04-14T04:20:16Z"
+    mac: ENC[AES256_GCM,data:R0Hh1YvW0uteHPFbWH1PQKtwkiXqZMzFy1DWGmS6VFnAOwf0L3QpHgablUlRi+Wv5RbCA/iz2X+hXout554tAtLKk3xNf8FvsqlznbRIPYA4KxtfAlKFuYMqnorKIZlcqHT+ZgYmZihEPkQ/4nMAX4Q+amLaefW3k2NFBEoEEjE=,iv:LTtvK51fRbzLLjVVA+BE7LbOGvQzm1LbGDTP5Bddnpc=,tag:TBmcxPsvPGYrQIEDLdLbhQ==,type:str]
     unencrypted_suffix: _unencrypted
-    version: 3.12.1
+    version: 3.12.2

--- a/system/services/homelab/default.nix
+++ b/system/services/homelab/default.nix
@@ -23,10 +23,12 @@
         worker.enable = true;
       };
       calibre-web.enable = true;
+      glance.enable = true;
       immich.enable = true;
       miniflux.enable = true;
       qbittorrent.enable = true;
       seerr.enable = true;
     };
+    homelab.rootService = config.services.glance.settings.server.port;
   };
 }

--- a/system/services/homelab/default.nix
+++ b/system/services/homelab/default.nix
@@ -24,8 +24,9 @@
       };
       calibre-web.enable = true;
       immich.enable = true;
-      seerr.enable = true;
+      miniflux.enable = true;
       qbittorrent.enable = true;
+      seerr.enable = true;
     };
   };
 }

--- a/system/services/homelab/glance.nix
+++ b/system/services/homelab/glance.nix
@@ -7,73 +7,89 @@ let
   cfg = config.services.glance;
 in
 {
-  services.glance = {
-    enable = true;
-    settings = {
-      server = {
-        port = 5678;
-        host = "0.0.0.0";
+  config = lib.mkIf cfg.enable {
+    services.glance = {
+      settings = {
+        server = {
+          port = 5678;
+          host = "0.0.0.0";
+        };
+        auth = {
+          secret-key = {
+            _secret = config.sops.secrets."glance/secret-key".path;
+          };
+          users = {
+            admin = {
+              password = {
+                _secret = config.sops.secrets."glance/admin-password".path;
+              };
+            };
+          };
+        };
+        theme = {
+          background-color = "240 21 15";
+          contrast-multiplier = 1.2;
+          primary-color = "217 92 83";
+          positive-color = "115 54 76";
+          negative-color = "347 70 65";
+        };
+        pages = [
+          (lib.mkIf config.services.homepage-dashboard.enable {
+            name = "Homepage";
+            columns = [
+              {
+                size = "full";
+                widgets = [
+                  {
+                    title = "Homepage";
+                    title-url = "https://gethomepage.dev";
+                    type = "iframe";
+                    source = "https://homepage.${config.host.address}";
+                    height = 800;
+                  }
+                ];
+              }
+            ];
+          })
+          {
+            name = "Feed";
+            columns = [
+              {
+                size = "small";
+                widgets = [
+                  { type = "calendar"; }
+                ];
+              }
+              {
+                size = "full";
+                widgets = [
+                  {
+                    type = "group";
+                    widgets = [
+                      { type = "hacker-news"; }
+                      { type = "lobsters"; }
+                    ];
+                  }
+                ];
+              }
+              {
+                size = "small";
+                widgets = [
+                  {
+                    type = "weather";
+                    location = "Dongguan, China";
+                    units = "metric";
+                  }
+                ];
+              }
+            ];
+          }
+        ];
       };
-      theme = {
-        background-color = "240 21 15";
-        contrast-multiplier = 1.2;
-        primary-color = "217 92 83";
-        positive-color = "115 54 76";
-        negative-color = "347 70 65";
-      };
-      pages = [
-        (lib.mkIf config.services.homepage-dashboard.enable {
-          name = "Homepage";
-          columns = [
-            {
-              size = "full";
-              widgets = [
-                {
-                  title = "Homepage";
-                  title-url = "https://gethomepage.dev";
-                  type = "iframe";
-                  source = "https://homepage.${config.host.address}";
-                  height = 800;
-                }
-              ];
-            }
-          ];
-        })
-        {
-          name = "Feed";
-          columns = [
-            {
-              size = "small";
-              widgets = [
-                { type = "calendar"; }
-              ];
-            }
-            {
-              size = "full";
-              widgets = [
-                {
-                  type = "group";
-                  widgets = [
-                    { type = "hacker-news"; }
-                    { type = "lobsters"; }
-                  ];
-                }
-              ];
-            }
-            {
-              size = "small";
-              widgets = [
-                {
-                  type = "weather";
-                  location = "Dongguan, China";
-                  units = "metric";
-                }
-              ];
-            }
-          ];
-        }
-      ];
+    };
+    sops.secrets = {
+      "glance/secret-key" = { };
+      "glance/admin-password" = { };
     };
   };
-  homelab.rootService = cfg.settings.server.port;
 }


### PR DESCRIPTION
- **clipboard: enable wl-clip-persist**
- **Revert "homelab/miniflux: disable by default"**
- **niri: enable screenlock keybind when locked**
- **tmux: use set instead of set-option**
- **tmux: set default-terminal to tmux-256color**
- **tmux: dont limit status length**
- **tmux: use catppuccin theme**
- **patch: fix home-manager patches being set to empty**
- **fish: dont generate man cache**
- **x1c12: add intel npu driver**
- **rss: enable**
- **glance: add authentication**
